### PR TITLE
iio_utils: fix use-after-free in read_sysfs_string()

### DIFF
--- a/iio_utils.c
+++ b/iio_utils.c
@@ -416,7 +416,8 @@ int read_sysfs_string(const char *filename, const char *basedir, char **str)
 	if (ret < 0) {
 		if (NULL != *str)
 			free(*str);
-
+		fclose(sysfsfp);
+		goto error_free;
 	}
 	ret = strlen(*str);
 


### PR DESCRIPTION
When fread() fails and returns a negative value, the code would free the allocated string buffer but then continue execution, leading to use-after-free bugs in the subsequent strlen() call and array access.

Fix this by closing the file and jumping to the error cleanup path immediately after freeing the buffer on read failure, preventing any further access to the freed memory.